### PR TITLE
Fix bug, do not replace hierarchy from IP as this causes incorrect name. Fix #105

### DIFF
--- a/pynq_composable/parser.py
+++ b/pynq_composable/parser.py
@@ -364,7 +364,7 @@ class HWHComposable:
                 if not key:
                     key = switch_conn[d].get('fullname')
                 dictionary = default_dfx_dict
-            key = key.replace(self._hier, '').lstrip('/')
+            key = key.split('/')[-1]
             if key not in static_dict.keys():
                 dictionary[key] = dict()
 


### PR DESCRIPTION
Replacing the hierarchy name in the full IP name causes incorrect name in the `c_dict` when the hierarchy name is contained in the IP name. 