### PR TITLE
Make evaluation more comprehensive

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/pynq_composable/composable.py
+++ b/pynq_composable/composable.py
@@ -534,15 +534,19 @@ class Composable(DefaultHierarchy):
                 if i == len(linear_pipeline) - 1:
                     break
                 ckey = self._relative_path(ip._fullpath, 'si')
-                si = self._c_dict[ckey]['si']
+                csi = self._c_dict[ckey]['si']
+                cmi = self._c_dict[ckey].get('mi')
                 nextip = linear_pipeline[i+1]
                 nkey = self._relative_path(nextip._fullpath, 'mi')
-                mi = self._c_dict[nkey]['mi']
+                nmi = self._c_dict[nkey]['mi']
+                nsi = self._c_dict[nkey].get('si')
 
                 if ckey not in in_use.keys():
-                    in_use[ckey] = {'si': si}
+                    in_use[ckey] = {'si': csi}
                 elif 'si' not in in_use[ckey].keys():
-                    in_use[ckey]['si'] = si
+                    in_use[ckey]['si'] = csi
+                if cmi and 'mi' not in in_use[ckey].keys():
+                    in_use[ckey]['mi'] = cmi
 
                 if (lensi := len(in_use[ckey]['si'])) == 0:
                     raise SystemError(f'Node {ckey} has {lensi} free '
@@ -553,9 +557,11 @@ class Composable(DefaultHierarchy):
                 in_use[ckey]['si'] = in_use[ckey]['si'][1:]
 
                 if nkey not in in_use.keys():
-                    in_use[nkey] = {'mi': mi}
+                    in_use[nkey] = {'mi': nmi}
                 elif 'mi' not in in_use[nkey].keys():
-                    in_use[nkey]['mi'] = mi
+                    in_use[nkey]['mi'] = nmi
+                if nsi and 'si' not in in_use[nkey].keys():
+                    in_use[nkey]['si'] = nsi
 
                 if (lenmi := len(in_use[nkey]['mi'])) == 0:
                     raise SystemError(f'Node {nkey} has {lenmi} free '
@@ -564,6 +570,7 @@ class Composable(DefaultHierarchy):
 
                 index = in_use[nkey]['mi'][0]
                 in_use[nkey]['mi'] = in_use[nkey]['mi'][1:]
+
                 switch_conf[index] = value
                 graph.edge(ckey, nkey,
                            label=_edge_label(value, index, gdebug))

--- a/pynq_composable/composable.py
+++ b/pynq_composable/composable.py
@@ -764,7 +764,8 @@ class Composable(DefaultHierarchy):
 
         self.compose(pipeline)
 
-    def tap(self, ip: Union[Type[DefaultIP], int] = None) -> None:
+    def tap(self, ip: Union[Type[DefaultIP], int] = None,
+            sink: bool = True) -> None:
         """Observe the output of an IP object in the current pipeline
 
         Tap into the output of the IP cores in the current pipeline
@@ -783,6 +784,9 @@ class Composable(DefaultHierarchy):
             Examples:
                 tap(cpipe.dilate)
                 tap(6)
+        sink: bool
+            True: Keep sink of original pipeline as sink of tap pipeline
+            False: Do not keep sink of original pipeline as sink tap pipeline
         """
 
         if self._current_pipeline is None:
@@ -812,10 +816,8 @@ class Composable(DefaultHierarchy):
             if len(self._c_dict[key]['si']) != 1:
                 raise SystemError("tap into an IP with multiple outputs is "
                                   "not supported")
-
-            for _, v in self.c_dict.default.items():
-                if v.get('fullpath') == self._current_pipeline[-1]._fullpath:
-                    new_list.append(self._current_pipeline[-1])
+        if sink:
+            new_list.append(self._current_pipeline[-1])
 
         self._untapped_pipeline = self._current_pipeline.copy()
         self.compose(new_list)

--- a/tests/test_composable.py
+++ b/tests/test_composable.py
@@ -238,7 +238,7 @@ def test_composable_tap(hierarchy):
     pipe = eval(pipelines[0][0])
     cpipe.compose(pipe)
     assert ipdevice.ip.memory == pipelines[0][1]
-    cpipe.tap(pipe[4])
+    cpipe.tap(pipe[3])
     assert ipdevice.ip.memory == pipelines[1][1]
     cpipe.untap()
     assert ipdevice.ip.memory == pipelines[0][1]
@@ -249,7 +249,7 @@ def test_composable_tap_by_index(hierarchy):
     pipe = eval(pipelines[0][0])
     cpipe.compose(pipe)
     assert ipdevice.ip.memory == pipelines[0][1]
-    cpipe.tap(4)
+    cpipe.tap(3)
     assert ipdevice.ip.memory == pipelines[1][1]
     cpipe.untap()
     assert ipdevice.ip.memory == pipelines[0][1]
@@ -395,7 +395,7 @@ def test_composable_insert_list(hierarchy):
     pipe = eval(pipelines[1][0])
     cpipe.compose(pipe)
     assert ipdevice.ip.memory == pipelines[1][1]
-    cpipe.insert(([cpipe.f5, cpipe.f6, cpipe.f7], 5))
+    cpipe.insert(([cpipe.f4, cpipe.f5, cpipe.f6], 4))
     assert ipdevice.ip.memory == pipelines[0][1]
 
 

--- a/tests/test_composable.py
+++ b/tests/test_composable.py
@@ -551,12 +551,13 @@ def test_default_paths(ipdevice):
     assert cpipe.axis_switch.mi[12] == 0
     cpipe.tap(0)
     assert cpipe.axis_switch.mi[12] == 12
-    pipe = eval(pipelines[0][0])
+    pipeline = pipelines[0][0]
+    pipeline = pipeline.replace('source_data', 'data_in')
+    pipeline = pipeline.replace('sink_data', 'data_out')
+    pipe = eval(pipeline)
     cpipe.compose(pipe)
     conf1 = pipelines[0][1].copy()
-    conf1['112'] = 12
     assert ipdevice.ip.memory == conf1
-    cpipe.tap(4)
+    cpipe.tap(3)
     conf2 = pipelines[1][1].copy()
-    conf2['112'] = 12
     assert ipdevice.ip.memory == conf2

--- a/tests/test_composable.py
+++ b/tests/test_composable.py
@@ -103,7 +103,10 @@ pipes_fork_exc = [
 
 broken_pipelines = [
     "[cpipe.source_data, cpipe.f3, cpipe.join, cpipe.sink_data]",
-    "[cpipe.source_data, cpipe.fork, cpipe.f3, cpipe.sink_data]"
+    "[cpipe.source_data, cpipe.fork, cpipe.f3, cpipe.sink_data]",
+    "[cpipe.source_data, cpipe.f1, cpipe.f2, cpipe.f3]",
+    "[cpipe.f1, cpipe.f2, cpipe.f3, cpipe.sink_data]",
+    "[cpipe.f1, cpipe.f2, cpipe.f3, cpipe.f4]"
 ]
 
 

--- a/tests/test_composable.py
+++ b/tests/test_composable.py
@@ -554,8 +554,7 @@ def test_default_paths(ipdevice):
     pipeline = pipelines[0][0]
     pipeline = pipeline.replace('source_data', 'data_in')
     pipeline = pipeline.replace('sink_data', 'data_out')
-    pipe = eval(pipeline)
-    cpipe.compose(pipe)
+    cpipe.compose(eval(pipeline))
     conf1 = pipelines[0][1].copy()
     assert ipdevice.ip.memory == conf1
     cpipe.tap(3)


### PR DESCRIPTION
- Make sure `mi` and `si` are considered for the source and sink of a pipeline
- Add test cases to evaluate such cases
- Fix tests
- Include Python 3.8 and 3.9 to the test matrix