### PR TITLE
Update Makefile: fix Vivado ERROR Common 17-53

### DIFF
--- a/boards/Pynq-ZU/Makefile
+++ b/boards/Pynq-ZU/Makefile
@@ -23,7 +23,7 @@ project:
 	cp default_paths.json overlay/$(overlay_name)_paths.json
 
 clean:
-	rm -rf *.jou *.log NA *.str .Xil/
+	rm -rf *.jou *.log NA *.str .Xil/ $(overlay_name)
 
 distclean: clean
 	rm -rf $(overlay_name) *.zip


### PR DESCRIPTION
Hi,

Currently, if building process is interrupted and user tries to `make` again, it will cause:
```
ERROR: [Common 17-53] User Exception: Project already exists on disk, please use '-force' option to overwrite.
```

I propose to remove the Vivado project directory when execute `make clean`.